### PR TITLE
make release.yml build the binary and publish it to github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - release
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
 
@@ -89,3 +89,39 @@ jobs:
           pip install twine
           python setup.py sdist bdist_wheel
           twine upload --verbose -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
+
+  build_binary:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: setup pyinstaller
+        run: pip install pyinstaller
+      - name: build the tool
+        run: |
+          python setup.py install
+          python setup.py build
+      - name: build the binary using pyinstaller
+        run: |
+          pip uninstall -y typing
+          pyinstaller --onefile main.py --name doxy-helm
+
+      - name: create a tag for the release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ github.sha }}',
+              sha: context.sha
+            })
+      - name: publish the binary in a release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/doxy-helm.exe
+          name: "Release ${{ github.run_number}}"
+          tag_name: v${{ github.sha }}     
+          target_commitish: release


### PR DESCRIPTION
This adds to the release.yml workflow in the CI a step to package the tool using pyinstaller and publish the resulting static executable to github releases. The release tag is created automatically in the format "v{{hash}}", and the release name is "Release {{number}}" where number is a counter value from github.run_number.

Currently only the executable runs only on windows, although support for Linux and MacOS isn't too hard to add and will be added soon.