### PR TITLE
make the job that builds the binary run on multiple operating systems using the strategy matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,10 @@ jobs:
           twine upload --verbose -u __token__ -p ${{ secrets.PYPI_TOKEN }} dist/*
 
   build_binary:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
@@ -106,7 +109,7 @@ jobs:
       - name: build the binary using pyinstaller
         run: |
           pip uninstall -y typing
-          pyinstaller --onefile main.py --name doxy-helm
+          pyinstaller --onefile main.py --name helm2readme
 
       - name: create a tag for the release
         uses: actions/github-script@v7
@@ -115,13 +118,13 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/v${{ github.sha }}',
+              ref: 'refs/tags/v-${{ matrix.os }}-${{ github.sha }}',
               sha: context.sha
             })
       - name: publish the binary in a release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/doxy-helm.exe
-          name: "Release ${{ github.run_number}}"
-          tag_name: v${{ github.sha }}     
+          files: dist/helm2readme*
+          name: "Release ${{ github.run_number  }} ${{ matrix.os }}"
+          tag_name: v-${{ matrix.os }}-${{ github.sha }}     
           target_commitish: release


### PR DESCRIPTION
This PR modifies the build_binary job introduced in a previous PR to run on the 3 major operating systems instead of just windows. This is done without any duplication of job description, but simply by using the matrix option (used to run several instances of the same job across all possible combination of several variables that each have several values, in this case the only variable is the OS to build on, its possible values are windows and ubuntu and MacOS).

Running the same job on different runners is necessary because Pyinstaller is not a cross-compiler, the OS it runs on will be the only OS that the resulting binary will be able to run on. This means that we must run it on all 3 operating systems if we want 3 binaries for each operating system.

Also, the binary is now named `helm2readme` instead of the older doxy-helm. This is the start of a rename effort that will eventually rename this repo, the docker images, and the PyPI package.